### PR TITLE
feat. 대기열 유저  위치확인 & 유저 활성화

### DIFF
--- a/src/main/java/com/example/booking/controller/queue/QueueController.java
+++ b/src/main/java/com/example/booking/controller/queue/QueueController.java
@@ -6,10 +6,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @Tag(name = "토큰")
 @RestController
@@ -33,5 +30,10 @@ public class QueueController {
         return ResponseEntity.ok(response);
     }
 
-
+    //자기 위치 로직 api로 확인
+    //캐치테이블 같은 곳 보니 매번 번호 체크가 되는거 보니 api호출이 필요할거라 판단
+    @GetMapping("/position/{userId}")
+    public ResponseEntity<Integer> getUserPositionInQueue(@PathVariable Long userId) {
+        return ResponseEntity.ok(tokenService.getUserPositionInQueue(userId));
+    }
 }

--- a/src/main/java/com/example/booking/controller/queue/scheduler/TokenExpiryScheduler.java
+++ b/src/main/java/com/example/booking/controller/queue/scheduler/TokenExpiryScheduler.java
@@ -16,12 +16,17 @@ public class TokenExpiryScheduler {
     @Scheduled(fixedRate = 300000)
     public void scheduledExpireTokens() {
         expireTokens();
+        activateQueuedUsers();
     }
 
+    //비활성화 스케줄러
     public void expireTokens() {
         tokenService.expireTokens();
         tokenService.expireInactiveActiveTokens();
     }
 
-
+    //active 스케줄러
+    public void activateQueuedUsers() {
+        tokenService.activateQueuedUsers();
+    }
 }

--- a/src/main/java/com/example/booking/domain/queue/Token.java
+++ b/src/main/java/com/example/booking/domain/queue/Token.java
@@ -1,12 +1,14 @@
 package com.example.booking.domain.queue;
 
 import com.example.booking.common.exception.NotReservableException;
+import com.example.booking.common.exception.UserNotFoundException;
 import com.example.booking.infra.token.entity.TokenStatus;
 import lombok.Builder;
 import lombok.Getter;
 
 import java.time.Duration;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 @Getter
@@ -18,6 +20,7 @@ public class Token {
     private final LocalDateTime expiredAt;
     private final TokenStatus status;
     private final LocalDateTime lastActivityAt;
+    private final LocalDateTime createdAt;
 
     public static Token generate(Long userId) {
         String tokenString = UUID.randomUUID().toString();
@@ -28,6 +31,7 @@ public class Token {
                 .expiredAt(expiresAt)
                 .status(TokenStatus.WAITING)
                 .lastActivityAt(LocalDateTime.now())
+                .createdAt(LocalDateTime.now())
                 .build();
     }
 
@@ -43,6 +47,7 @@ public class Token {
                 .expiredAt(expiredAt)
                 .status(TokenStatus.EXPIRED)
                 .lastActivityAt(lastActivityAt)
+                .createdAt(createdAt)
                 .build();
     }
 
@@ -54,6 +59,7 @@ public class Token {
                 .expiredAt(expiredAt)
                 .status(TokenStatus.ACTIVE)
                 .lastActivityAt(LocalDateTime.now())
+                .createdAt(createdAt)
                 .build();
     }
 
@@ -65,6 +71,7 @@ public class Token {
                 .expiredAt(expiredAt)
                 .status(status)
                 .lastActivityAt(LocalDateTime.now())
+                .createdAt(createdAt)
                 .build();
     }
 
@@ -76,5 +83,14 @@ public class Token {
         if (this.status != TokenStatus.ACTIVE || this.isExpired()) {
             throw new NotReservableException("토큰 상태를 확인해주세요.");
         }
+    }
+
+    public static int getUserPositionInQueue(List<Token> queue, Long userId) {
+        for (int i = 0; i < queue.size(); i++) {
+            if (queue.get(i).getUserId().equals(userId)) {
+                return i + 1;
+            }
+        }
+        throw new UserNotFoundException("유저를 찾을 수 없습니다");
     }
 }

--- a/src/main/java/com/example/booking/domain/queue/TokenRepository.java
+++ b/src/main/java/com/example/booking/domain/queue/TokenRepository.java
@@ -1,5 +1,7 @@
 package com.example.booking.domain.queue;
 
+import com.example.booking.infra.token.entity.TokenStatus;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -8,4 +10,10 @@ public interface TokenRepository {
 
     Optional<Token> findByToken(String token);
     List<Token> findActiveTokens();
+
+    int countByStatus(TokenStatus tokenStatus);
+
+    List<Token> findTopByStatusOrderByCreatedAt(TokenStatus tokenStatus, int i);
+
+    List<Token> findAllByOrderByCreatedAt();
 }

--- a/src/main/java/com/example/booking/infra/token/TokenJpaRepository.java
+++ b/src/main/java/com/example/booking/infra/token/TokenJpaRepository.java
@@ -3,6 +3,8 @@ package com.example.booking.infra.token;
 import com.example.booking.infra.token.entity.TokenEntity;
 import com.example.booking.infra.token.entity.TokenStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -12,4 +14,10 @@ public interface TokenJpaRepository extends JpaRepository<TokenEntity, Long> {
     Optional<TokenEntity> findByToken(String token);
     List<TokenEntity> findByStatus(TokenStatus status);
 
+    int countByStatus(TokenStatus status);
+
+    @Query("SELECT t FROM TokenEntity t WHERE t.status = :status ORDER BY t.createdAt ASC")
+    List<TokenEntity> findTopNByStatusOrderByCreatedAt(@Param("status") TokenStatus status, @Param("n") int n);
+
+    Optional<TokenEntity> findAllByOrderByCreatedAt();
 }

--- a/src/main/java/com/example/booking/infra/token/TokenRepositoryImpl.java
+++ b/src/main/java/com/example/booking/infra/token/TokenRepositoryImpl.java
@@ -33,4 +33,23 @@ public class TokenRepositoryImpl implements TokenRepository {
                 .map(TokenEntity::toModel)
                 .collect(Collectors.toList());
     }
+
+    @Override
+    public int countByStatus(TokenStatus status) {
+        return tokenJpaRepository.countByStatus(status);
+    }
+
+    @Override
+    public List<Token> findTopByStatusOrderByCreatedAt(TokenStatus status, int n) {
+        return tokenJpaRepository.findTopNByStatusOrderByCreatedAt(status, n).stream()
+                .map(TokenEntity::toModel)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public List<Token> findAllByOrderByCreatedAt() {
+        return tokenJpaRepository.findAllByOrderByCreatedAt().stream()
+                .map(TokenEntity::toModel)
+                .collect(Collectors.toList());
+    }
 }

--- a/src/main/java/com/example/booking/infra/token/entity/TokenEntity.java
+++ b/src/main/java/com/example/booking/infra/token/entity/TokenEntity.java
@@ -38,6 +38,9 @@ public class TokenEntity {
     @Column(nullable = false)
     private LocalDateTime lastActivityAt;
 
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
     public Token toModel() {
         return Token.builder()
                 .id(id)
@@ -46,6 +49,7 @@ public class TokenEntity {
                 .expiredAt(expiredAt)
                 .status(status)
                 .lastActivityAt(lastActivityAt)
+                .createdAt(createdAt)
                 .build();
     }
 
@@ -57,6 +61,7 @@ public class TokenEntity {
                 .expiredAt(token.getExpiredAt())
                 .status(token.getStatus())
                 .lastActivityAt(token.getLastActivityAt())
+                .createdAt(token.getCreatedAt())
                 .build();
     }
 }


### PR DESCRIPTION
# 자기 위치 로직 api로 확인
캐치테이블 같은 곳 보니 매번 번호 체크가 되는거 보니 api호출이 필요할거라 판단

# 대기열 유저 활성화
현재 활성 유저 수를 확인하고, 최대 활성 유저 수를 넘지 않으면 대기 중인 유저를 활성화